### PR TITLE
Rename browser with name of 'IE' to 'Internet Explorer'

### DIFF
--- a/fake_useragent/utils.py
+++ b/fake_useragent/utils.py
@@ -29,6 +29,8 @@ def get_browsers():
     html = html.split('<td>&nbsp;</td>')[0]
 
     browsers = re.findall(r'\.asp">(.+?)<', html, re.UNICODE)
+    browsers = ["Internet Explorer" if browser == "IE" else browser
+                for browser in browsers]
     browsers_statistics = re.findall(r'"right">(.+?)\s', html, re.UNICODE)
 
     # TODO: ensure encoding


### PR DESCRIPTION
The code currently assumes that it can pass the browser name extracted from the page on w3schools.com directly into the URL for useragentstring.com.

Recently, w3schools text changed its links text from "Internet Explorer" into "IE".

This caused the list of Internet Explorer user-agent strings to be empty.

As such, calling `ua.random` will occasionally fail with an "list index out of range" exception.
