### PR TITLE
Fix for empty data_browser

### DIFF
--- a/fake_useragent/fake.py
+++ b/fake_useragent/fake.py
@@ -133,6 +133,9 @@ class FakeUserAgent(object):
             else:
                 browser = settings.SHORTCUTS.get(attr, attr)
 
+            if not self.data_browsers[browser]:
+                return random.choice(settings.SHORTCUTS.values())
+
             return random.choice(self.data_browsers[browser])
         except (KeyError, IndexError):
             if self.fallback is None:


### PR DESCRIPTION
For some unknown reason the data_browser is empty. We can use the FAKEUSERAGENT_FALLBACK settings, but that prints an ugly warning.