### PR TITLE
Add `__name__` to the default safe_attrs

### DIFF
--- a/fake_useragent/fake.py
+++ b/fake_useragent/fake.py
@@ -18,7 +18,7 @@ class FakeUserAgent(object):
         path=settings.DB,
         fallback=None,
         verify_ssl=True,
-        safe_attrs=tuple(),
+        safe_attrs=tuple('__name__',),
     ):
         assert isinstance(cache, bool), \
             'cache must be True or False'


### PR DESCRIPTION
Hi there, 

this is mostly a compatibility fix with the builtin `help` function: here's an example (Python 3.6):
```python
>>> import fake_useragent
>>> ua = fake_useragent.FakeUserAgent()
>>> help(ua)
Traceback (most recent call last):
  File "/home/althonos/.local/lib/python3.6/site-packages/fake_useragent/fake.py", line 136, in __getattr__
    return random.choice(self.data_browsers[browser])
KeyError: 'name'

During handling of the above exception, another exception occurred:

...
```

`help` will crash on any `FakeUserAgent` instance that does not have `__name__` in the `safe_attrs`. This means that `help` will also crash on any object that has a `FakeUserAgent` attribute or property, and so on.

Since I'm confident there aren't many persons aware of this, adding `__name__` to the default `safe_attrs` value will prevent this bug without having end-users to manually patch it.