### PR TITLE
Travis CI: Test on current versions of Python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,21 @@
-dist: trusty
 language: python
 python:
   - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
+  - "3.8"
+cache: pip
 install:
-  - pip install -U setuptools
-  - pip install -U pip
-  - pip install -U wheel
-  - pip install -U tox
+  - pip install --upgrade pip
+  - pip install --upgrade setuptools tox wheel
 script:
   - export TOXENV=py`python -c 'import sys; print("".join(map(str, sys.version_info[:2])))'`
   - echo "$TOXENV"
-
   - tox
 after_success:
   - pip install codecov
   - codecov
-cache: pip
 notifications:
   email: true
 
@@ -31,4 +28,4 @@ deploy:
   on:
     tags: true
     all_branches: true
-    python: 2.7
+    python: 3.7


### PR DESCRIPTION
Trusty and Python 3.4 are end of life.  pip is getting a dependency resolver so give it all dependencies together.