### PR TITLE
Modified table class name for non-cached UserAgent

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -7,6 +7,7 @@ Original author:
 Contributors:
 
     Alexey Shablevskiy @pcinkh <pcinkh@gmail.com>
+    Jordan Vuong @Jordan9675
     Mohamad Nour Chawich @mochawich
     Simon Wenmouth @simon-wenmouth
 

--- a/fake_useragent/settings.py
+++ b/fake_useragent/settings.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import, unicode_literals
 import os
 import tempfile
 
-__version__ = '0.1.11'
+__version__ = '0.1.12'
 
 DB = os.path.join(
     tempfile.gettempdir(),

--- a/fake_useragent/utils.py
+++ b/fake_useragent/utils.py
@@ -96,7 +96,7 @@ def get_browsers(verify_ssl=True):
     """
     html = get(settings.BROWSERS_STATS_PAGE, verify_ssl=verify_ssl)
     html = html.decode('utf-8')
-    html = html.split('<table class="w3-table-all notranslate">')[1]
+    html = html.split('<table class="ws-table-all notranslate">')[1]
     html = html.split('</table>')[0]
 
     pattern = r'\.asp">(.+?)<'


### PR DESCRIPTION
It seems like the class attribute associated to the table on https://www.w3schools.com/browsers/default.asp has changed thus leading to `IndexError` when trying to initialize `UserAgent` with `cache=False`