### PR TITLE
Update utils.get_browser parsing

### DIFF
--- a/fake_useragent/utils.py
+++ b/fake_useragent/utils.py
@@ -96,7 +96,7 @@ def get_browsers(verify_ssl=True):
     """
     html = get(settings.BROWSERS_STATS_PAGE, verify_ssl=verify_ssl)
     html = html.decode('utf-8')
-    html = html.split('<table class="w3-table-all notranslate">')[1]
+    html = html.split('<table class="ws-table-all notranslate">')[1]
     html = html.split('</table>')[0]
 
     pattern = r'\.asp">(.+?)<'


### PR DESCRIPTION
The default BROWSERS_STATS_PAGE (https://www.w3schools.com/browsers/default.asp) has changed their html tags. This broke the hardcoded parsing. The html element is now `<table class="ws-table-all notranslate">`