### PR TITLE
Remove obsolete mock #140

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -1,6 +1,15 @@
 name: Test & Deploy fake-useragent
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - *
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
 
 jobs:
   test:

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
     tags:
-      - *
+      - "*"
   pull_request:
     branches:
       - master

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ exceptiongroup==1.0.0
 filelock==3.8.0
 iniconfig==1.1.1
 isort==5.10.1
-mock==4.0.3
 mypy-extensions==0.4.3
 packaging==21.3
 pathspec==0.10.1

--- a/tests/test_fake.py
+++ b/tests/test_fake.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import, unicode_literals
 import os
 from functools import partial
 
-import mock
+from unittest.mock import patch
 import pytest
 
 from fake_useragent import (
@@ -101,7 +101,7 @@ def test_fake_fallback():
         settings.CACHE_SERVER,
     ]
 
-    with mock.patch(
+    with patch(
         "fake_useragent.utils.Request",
         side_effect=partial(_request, denied_urls=denied_urls),
     ):
@@ -118,7 +118,7 @@ def test_fake_no_fallback():
         settings.CACHE_SERVER,
     ]
 
-    with mock.patch(
+    with patch(
         "fake_useragent.utils.Request",
         side_effect=partial(_request, denied_urls=denied_urls),
     ):
@@ -158,7 +158,7 @@ def test_fake_update_use_cache_server():
         "https://useragentstring.com",
     ]
 
-    with mock.patch(
+    with patch(
         "fake_useragent.utils.Request",
         side_effect=partial(_request, denied_urls=denied_urls),
     ):
@@ -171,7 +171,7 @@ def test_fake_update_use_cache_server():
         settings.CACHE_SERVER,
     ]
 
-    with mock.patch(
+    with patch(
         "fake_useragent.utils.Request",
         side_effect=partial(_request, denied_urls=denied_urls),
     ):
@@ -184,7 +184,7 @@ def test_fake_not_use_cache_server():
         "https://useragentstring.com",
     ]
 
-    with mock.patch(
+    with patch(
         "fake_useragent.utils.Request",
         side_effect=partial(_request, denied_urls=denied_urls),
     ):
@@ -199,7 +199,7 @@ def test_fake_update_not_use_cache_server():
         "https://useragentstring.com",
     ]
 
-    with mock.patch(
+    with patch(
         "fake_useragent.utils.Request",
         side_effect=partial(_request, denied_urls=denied_urls),
     ):
@@ -212,7 +212,7 @@ def test_fake_use_cache_server():
         "https://useragentstring.com",
     ]
 
-    with mock.patch(
+    with patch(
         "fake_useragent.utils.Request",
         side_effect=partial(_request, denied_urls=denied_urls),
     ):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,7 +6,7 @@ import json
 import os
 from functools import partial
 
-from unittest.mock import patch
+from unittest.mock import patch, ANY
 import pytest
 
 from fake_useragent import errors, settings, utils
@@ -66,12 +66,12 @@ def test_utils_get_cache_server():
         data.update(json.loads(line))
 
     expected = {
-        "chrome": mock.ANY,
-        "opera": mock.ANY,
-        "firefox": mock.ANY,
-        "safari": mock.ANY,
-        "edge": mock.ANY,
-        "internet explorer": mock.ANY,
+        "chrome": ANY,
+        "opera": ANY,
+        "firefox": ANY,
+        "safari": ANY,
+        "edge": ANY,
+        "internet explorer": ANY,
     }
 
     assert expected == data
@@ -90,12 +90,12 @@ def test_utils_load(path):
         mocked.assert_called()
 
     expected = {
-        "chrome": mock.ANY,
-        "edge": mock.ANY,
-        "firefox": mock.ANY,
-        "opera": mock.ANY,
-        "safari": mock.ANY,
-        "internet explorer": mock.ANY,
+        "chrome": ANY,
+        "edge": ANY,
+        "firefox": ANY,
+        "opera": ANY,
+        "safari": ANY,
+        "internet explorer": ANY,
     }
 
     assert expected == data
@@ -186,12 +186,12 @@ def test_utils_load_cached(path):
         mocked.assert_called()
 
     expected = {
-        "chrome": mock.ANY,
-        "edge": mock.ANY,
-        "firefox": mock.ANY,
-        "opera": mock.ANY,
-        "safari": mock.ANY,
-        "internet explorer": mock.ANY,
+        "chrome": ANY,
+        "edge": ANY,
+        "firefox": ANY,
+        "opera": ANY,
+        "safari": ANY,
+        "internet explorer": ANY,
     }
 
     assert expected == data
@@ -240,12 +240,12 @@ def test_utils_load_use_cache_server(path):
         data = utils.load(browsers, use_cache_server=True)
 
         expected = {
-            "chrome": mock.ANY,
-            "edge": mock.ANY,
-            "firefox": mock.ANY,
-            "opera": mock.ANY,
-            "safari": mock.ANY,
-            "internet explorer": mock.ANY,
+            "chrome": ANY,
+            "edge": ANY,
+            "firefox": ANY,
+            "opera": ANY,
+            "safari": ANY,
+            "internet explorer": ANY,
         }
 
         assert expected == data

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,7 +6,7 @@ import json
 import os
 from functools import partial
 
-import mock
+from unittest.mock import patch
 import pytest
 
 from fake_useragent import errors, settings, utils
@@ -50,7 +50,7 @@ def test_utils_get_retries():
 
     __retried_request.attempt = 0
 
-    with mock.patch(
+    with patch(
         "fake_useragent.utils.Request",
         side_effect=__retried_request,
     ):
@@ -80,7 +80,7 @@ def test_utils_get_cache_server():
 def test_utils_load(path):
     _load = utils.load
 
-    with mock.patch(
+    with patch(
         "fake_useragent.utils.load",
         side_effect=_load,
     ) as mocked:
@@ -162,7 +162,7 @@ def test_utils_update(path):
 
     _load = utils.load
 
-    with mock.patch(
+    with patch(
         "fake_useragent.utils.load",
         side_effect=_load,
     ) as mocked:
@@ -176,7 +176,7 @@ def test_utils_update(path):
 def test_utils_load_cached(path):
     _load = utils.load
 
-    with mock.patch(
+    with patch(
         "fake_useragent.utils.load",
         side_effect=_load,
     ) as mocked:
@@ -198,7 +198,7 @@ def test_utils_load_cached(path):
 
     expected = data
 
-    with mock.patch("fake_useragent.utils.load") as mocked:
+    with patch("fake_useragent.utils.load") as mocked:
         browsers = ["chrome", "edge", "internet explorer", "firefox", "safari", "opera"]
         data = utils.load_cached(path, browsers, use_cache_server=False)
 
@@ -212,7 +212,7 @@ def test_utils_load_no_use_cache_server(path):
         "https://useragentstring.com",
     ]
 
-    with mock.patch(
+    with patch(
         "fake_useragent.utils.Request",
         side_effect=partial(_request, denied_urls=denied_urls),
     ):
@@ -232,7 +232,7 @@ def test_utils_load_use_cache_server(path):
         "https://useragentstring.com",
     ]
 
-    with mock.patch(
+    with patch(
         "fake_useragent.utils.Request",
         side_effect=partial(_request, denied_urls=denied_urls),
     ):
@@ -257,7 +257,7 @@ def test_utils_load_use_cache_server_down(path):
         settings.CACHE_SERVER,
     ]
 
-    with mock.patch(
+    with patch(
         "fake_useragent.utils.Request",
         side_effect=partial(_request, denied_urls=denied_urls),
     ):

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,6 @@ deps =
     isort
     pytest
     pytest-cov
-    mock
 commands =
     black --check --diff .
     # Isort needs to be fixed (skip is not recognized anymore)


### PR DESCRIPTION
- Mock is no longer needed indeed on Python 3
- Avoid GitHub Actions being triggered twice in PR (due to push & pull_request trigger)