### PR TITLE
Add version to pyproject.toml + various improvements 

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -24,6 +24,8 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          check-latest: true
+          cache: "pip"
       - name: Install dependencies
         run: pip install -r requirements.txt
       - name: Run tests + lint check

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # fake-useragent
 
-Up to date simple useragent faker with real world database
+Up-to-date simple useragent faker with real world database
 
 ## Features
 
@@ -180,6 +180,15 @@ tox
 ```
 
 ### Changelog
+
+- 0.1.14 November 5, 2022
+
+  - Improve code quality stanards using modern Python >=3.7 syntax
+  - Migrated to `pyproject.toml` build system format + syntax check
+  - Add additional classifiers to the toml file
+  - Improved `tox.ini` file
+  - Improved GitHub Actions job using pip cache
+  - And various small fixes
 
 - 0.1.13 October 21, 2022
 

--- a/fake_useragent/settings.py
+++ b/fake_useragent/settings.py
@@ -1,8 +1,13 @@
 import os
 import tempfile
-import importlib.metadata
 
-__version__ = importlib.metadata.version("fake-useragent")
+try:
+    from importlib import metadata
+except ImportError:
+    # Running on pre-3.8 Python; use importlib-metadata package
+    import importlib_metadata as metadata
+
+__version__ = metadata.version("fake-useragent")
 
 DB = os.path.join(
     tempfile.gettempdir(),

--- a/fake_useragent/settings.py
+++ b/fake_useragent/settings.py
@@ -1,7 +1,8 @@
 import os
 import tempfile
+import importlib.metadata
 
-__version__ = "0.1.13"
+__version__ = importlib.metadata.version("fake-useragent")
 
 DB = os.path.join(
     tempfile.gettempdir(),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ classifiers = [
     "Programming Language :: Python :: 3 :: Only",
     "Operating System :: OS Independent",
 ]
-dynamic = ["version"]
 
 [project.readme]
 file = "README.md"
@@ -45,6 +44,3 @@ Homepage = "https://github.com/fake-useragent/fake-useragent"
 packages = ["fake_useragent"]
 zip-safe = false
 include-package-data = true
-
-[tool.setuptools.dynamic]
-version = {attr = "fake_useragent.settings.__version__"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fake-useragent"
+version = "0.1.14"
+license = "Apache-2.0"
 authors = [
     {name = "Victor Kovtun", email = "hellysmile@gmail.com"},
     {name = "Melroy van den Berg", email = "melroy@melroy.org"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,6 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "fake-useragent"
 version = "0.1.14"
-license = "Apache-2.0"
 authors = [
     {name = "Victor Kovtun", email = "hellysmile@gmail.com"},
     {name = "Melroy van den Berg", email = "melroy@melroy.org"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
     {name = "Victor Kovtun", email = "hellysmile@gmail.com"},
     {name = "Melroy van den Berg", email = "melroy@melroy.org"},
 ]
-description = "Up to date simple useragent faker with real world database"
+description = "Up-to-date simple useragent faker with real world database"
 keywords = [
     "user",
     "agent",
@@ -30,6 +30,10 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
     "Operating System :: OS Independent",
+    "Topic :: Internet :: WWW/HTTP",
+    "Topic :: Software Development",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Topic :: Utilities",
 ]
 
 [project.readme]


### PR DESCRIPTION
- Try to use pyproject.toml file as single source of truth
- Using `importlib` in Python 3.8 and higher, use `importlib_metadata` pre-3.8
- Add additional topics to classifiers
- Improved pip cache in GH Actions
