### PR TITLE
[BUG] Fix importlib resources/metadata on older Python versions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,0 @@
-include README.rst
-include LICENSE
-recursive-exclude * __pycache__
-recursive-exclude * *.py[co]
-graft tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,9 @@ authors = [
     {name = "Victor Kovtun", email = "hellysmile@gmail.com"},
     {name = "Melroy van den Berg", email = "melroy@melroy.org"},
 ]
+dependencies = [
+    "importlib-resources >= 5.0; python_version < '3.10'",
+]
 description = "Up-to-date simple useragent faker with real world database"
 keywords = [
     "user",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fake-useragent"
-version = "1.0.0"
+version = "1.0.1"
 authors = [
     {name = "Victor Kovtun", email = "hellysmile@gmail.com"},
     {name = "Melroy van den Berg", email = "melroy@melroy.org"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ authors = [
 ]
 dependencies = [
     "importlib-resources >= 5.0; python_version < '3.10'",
+    "importlib-metadata ~= 4.0; python_version < '3.8'",
 ]
 description = "Up-to-date simple useragent faker with real world database"
 keywords = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,5 +23,6 @@ pytest-cov==4.0.0
 six==1.16.0
 tomli==2.0.1
 tox==3.27.0
+validate-pyproject==0.10.1
 virtualenv==20.16.6
 zipp==3.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ coverage==6.5.0
 distlib==0.3.6
 exceptiongroup==1.0.0
 filelock==3.8.0
+importlib-metadata==5.0.0
 importlib-resources==5.10.0
 iniconfig==1.1.1
 isort==5.10.1
@@ -23,3 +24,4 @@ six==1.16.0
 tomli==2.0.1
 tox==3.27.0
 virtualenv==20.16.6
+zipp==3.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,15 +1,18 @@
 attrs==22.1.0
 black==22.10.0
+build==0.9.0
 click==8.1.3
 coverage==6.5.0
 distlib==0.3.6
 exceptiongroup==1.0.0
 filelock==3.8.0
+importlib-resources==5.10.0
 iniconfig==1.1.1
 isort==5.10.1
 mypy-extensions==0.4.3
 packaging==21.3
 pathspec==0.10.1
+pep517==0.13.0
 platformdirs==2.5.2
 pluggy==1.0.0
 py==1.11.0
@@ -19,5 +22,4 @@ pytest-cov==4.0.0
 six==1.16.0
 tomli==2.0.1
 tox==3.27.0
-validate-pyproject==0.10.1
 virtualenv==20.16.6

--- a/src/fake_useragent/utils.py
+++ b/src/fake_useragent/utils.py
@@ -1,3 +1,4 @@
+import sys
 import contextlib
 import inspect
 import io
@@ -7,10 +8,12 @@ import re
 import ssl
 import time
 
-try:
-    import importlib_resources as ilr
-except ImportError:  # Python 3.10
+
+# We need files() from Python 3.10 or higher
+if sys.version_info >= (3, 10):
     import importlib.resources as ilr
+else:
+    import importlib_resources as ilr
 
 from urllib.error import URLError
 from urllib.parse import quote_plus

--- a/src/fake_useragent/utils.py
+++ b/src/fake_useragent/utils.py
@@ -8,10 +8,9 @@ import ssl
 import time
 
 try:
-    import importlib.resources as ilr
-except ImportError:
-    # Running on pre-3.9 Python; use importlib-resources package
     import importlib_resources as ilr
+except ImportError:  # Python 3.10
+    import importlib.resources as ilr
 
 from urllib.error import URLError
 from urllib.parse import quote_plus

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,7 @@ deps =
     pytest
     pytest-cov
     validate-pyproject
+    importlib-resources
 commands =
     black --check --diff .
     # Isort needs to be fixed (skip is not recognized anymore)

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,6 @@ deps =
     pytest
     pytest-cov
     validate-pyproject
-    importlib-resources
 commands =
     black --check --diff .
     # Isort needs to be fixed (skip is not recognized anymore)


### PR DESCRIPTION
Trying to fix #153...

- [x] Add `importlib-metadata` & `importlib-resources` as dependencies
- [x] Check on specific Python version regarding the importlib resources (python v3.10 or higher) in order to have `files()` working
- [x] `importlib_metadata` should now also work on Python version before 3.8
- [x] Remove obsolete `MANIFEST.in` file
