### PR TITLE
Added properties for browser choices

### DIFF
--- a/src/fake_useragent/fake.py
+++ b/src/fake_useragent/fake.py
@@ -152,32 +152,26 @@ class FakeUserAgent:
     def edge(self):
         return self.__getattr__("edge")
 
-    
     @property
     def edge(self):
         return self.__getattr__("edge")
 
-    
     @property
     def ie(self):
         return self.__getattr__("ie")
 
-    
     @property
     def internetexplorer(self):
         return self.ie
 
-    
     @property
     def msie(self):
         return self.ie
 
-    
     @property
     def firefox(self):
         return self.__getattr__("firefox")
 
-    
     @property
     def ff(self):
         return self.firefox

--- a/src/fake_useragent/fake.py
+++ b/src/fake_useragent/fake.py
@@ -153,10 +153,6 @@ class FakeUserAgent:
         return self.__getattr__("edge")
 
     @property
-    def edge(self):
-        return self.__getattr__("edge")
-
-    @property
     def ie(self):
         return self.__getattr__("ie")
 

--- a/src/fake_useragent/fake.py
+++ b/src/fake_useragent/fake.py
@@ -140,6 +140,60 @@ class FakeUserAgent:
 
                 return self.fallback
 
+    @property
+    def chrome(self):
+        return self.__getattr__("chrome")
+
+    @property
+    def googlechrome(self):
+        return self.chrome
+
+    @property
+    def edge(self):
+        return self.__getattr__("edge")
+
+    
+    @property
+    def edge(self):
+        return self.__getattr__("edge")
+
+    
+    @property
+    def ie(self):
+        return self.__getattr__("ie")
+
+    
+    @property
+    def internetexplorer(self):
+        return self.ie
+
+    
+    @property
+    def msie(self):
+        return self.ie
+
+    
+    @property
+    def firefox(self):
+        return self.__getattr__("firefox")
+
+    
+    @property
+    def ff(self):
+        return self.firefox
+
+    @property
+    def safari(self):
+        return self.__getattr__("safari")
+
+    @property
+    def opera(self):
+        return self.__getattr__("opera")
+
+    @property
+    def random(self):
+        return self.__getattr__("random")
+
 
 # common alias
 UserAgent = FakeUserAgent


### PR DESCRIPTION
Added properties for the most common configurations recognized. As far as I can see, the tests should already cover these, as the attributes were already tested (generated by `__getattr__`).

This allows for code completion and it is helpful in the case of a potential implementation of static type checking, e.g. mypy.

![properties](https://user-images.githubusercontent.com/4533110/211674100-0106ddc5-bd76-4f42-97cb-0bc894e2c428.jpg)
