### PR TITLE
Lint Python code with ruff

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,0 +1,17 @@
+# https://beta.ruff.rs
+name: Ruff linter
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: pip install --user ruff
+      - run: ruff --format=github .

--- a/cache_scraper/cronjob_spider.py
+++ b/cache_scraper/cronjob_spider.py
@@ -1,16 +1,14 @@
 #!/usr/bin/env python3
 from multiprocessing import Process
 
-from scrapy.crawler import CrawlerRunner
-from scrapy.utils.project import get_project_settings
-from scrapy.utils.log import configure_logging
 from apscheduler.schedulers.blocking import BlockingScheduler
-
+from scrapy.crawler import CrawlerRunner
+from scrapy.utils.log import configure_logging
+from scrapy.utils.project import get_project_settings
+from twisted.internet import reactor
 from useragentscraper.spiders.useragent import (
     UserAgentSpider,
 )
-
-from twisted.internet import reactor
 
 
 # Create Process around the CrawlerRunner

--- a/cache_scraper/start_spider.py
+++ b/cache_scraper/start_spider.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 from scrapy.crawler import CrawlerProcess
 from scrapy.utils.project import get_project_settings
-
 from useragentscraper.spiders.useragent import (
     UserAgentSpider,
 )

--- a/cache_scraper/useragentscraper/middlewares.py
+++ b/cache_scraper/useragentscraper/middlewares.py
@@ -6,7 +6,6 @@
 from scrapy import signals
 
 # useful for handling different item types with a single interface
-from itemadapter import is_item, ItemAdapter
 
 
 class UserAgentSpiderMiddleware:

--- a/cache_scraper/useragentscraper/pipelines.py
+++ b/cache_scraper/useragentscraper/pipelines.py
@@ -2,7 +2,6 @@
 #
 # Don't forget to add your pipeline to the ITEM_PIPELINES setting
 # See: https://docs.scrapy.org/en/latest/topics/item-pipeline.html
-from twisted.enterprise import adbapi
 import logging
 
 logger = logging.getLogger(__name__)

--- a/cache_scraper/useragentscraper/spiders/useragent.py
+++ b/cache_scraper/useragentscraper/spiders/useragent.py
@@ -1,6 +1,6 @@
-import scrapy
-
 from urllib.parse import urlparse
+
+import scrapy
 
 
 class UserAgentSpider(scrapy.Spider):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,8 +11,6 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys
-import os
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,27 @@ content-type = "text/markdown"
 [project.urls]
 Homepage = "https://github.com/fake-useragent/fake-useragent"
 
+[tool.ruff]
+line-length = 142
+select = ["B", "C4", "C9", "E", "F", "I", "PL", "S", "SIM", "U", "W", "YTT"]
+ignore = ["B904", "C408", "PLW2901", "SIM105", "SIM108"]
+target-version = "py37"
+
+[tool.ruff.isort]
+known-first-party = ["fake_useragent"]
+
+[tool.ruff.mccabe]
+max-complexity = 13
+
+[tool.ruff.per-file-ignores]
+"src/fake_useragent/__init__.py" = ["F401"]
+"src/fake_useragent/fake.py" = ["B006", "S101"]
+"tests/*" = ["S", "SIM", "UP015"]
+
+[tool.ruff.pylint]
+max-args = 7
+max-branches = 13
+
 [tool.setuptools]
 zip-safe = false
 

--- a/src/fake_useragent/__init__.py
+++ b/src/fake_useragent/__init__.py
@@ -2,5 +2,6 @@ from fake_useragent.fake import FakeUserAgent, UserAgent  # noqa # isort:skip
 from fake_useragent.errors import (
     FakeUserAgentError,
     UserAgentError,
-)  # noqa # isort:skip
+)
+
 from fake_useragent.settings import __version__ as VERSION  # noqa # isort:skip

--- a/src/fake_useragent/utils.py
+++ b/src/fake_useragent/utils.py
@@ -1,13 +1,11 @@
-import sys
 import contextlib
 import inspect
-import io
 import json
 import os
 import re
 import ssl
+import sys
 import time
-
 
 # We need files() from Python 3.10 or higher
 if sys.version_info >= (3, 10):
@@ -15,15 +13,16 @@ if sys.version_info >= (3, 10):
 else:
     import importlib_resources as ilr
 
+from urllib import request
 from urllib.error import URLError
 from urllib.parse import quote_plus
-from urllib import request
+
 from fake_useragent.log import logger
 
 # Fallback method for retrieving data file
 try:
     from pkg_resources import resource_filename
-except:
+except ImportError:
     pass
 
 str_types = (str,)

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,5 +1,6 @@
-from fake_useragent import errors
 import unittest
+
+from fake_useragent import errors
 
 
 class TestErrors(unittest.TestCase):

--- a/tests/test_fake.py
+++ b/tests/test_fake.py
@@ -1,10 +1,10 @@
 import os
-import urllib
-from urllib import request
-from functools import partial
-
 import unittest
+import urllib
+from functools import partial
 from unittest.mock import patch
+from urllib import request
+
 import pytest
 
 from fake_useragent import (
@@ -222,7 +222,7 @@ class TestFake(unittest.TestCase):
             side_effect=partial(_request, denied_urls=denied_urls),
         ):
             with pytest.raises(FakeUserAgentError):
-                ua = UserAgent(use_external_data=True)
+                _ua = UserAgent(use_external_data=True)
 
     def test_fake_external_data_boolean(self):
         with pytest.raises(AssertionError):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,8 +1,7 @@
-import sys
-import os
-import time
-import io
 import json
+import os
+import sys
+import time
 from functools import partial
 
 if sys.version_info >= (3, 10):
@@ -10,14 +9,14 @@ if sys.version_info >= (3, 10):
 else:
     import importlib_resources as ilr
 
-import urllib
-from urllib.error import HTTPError
 import unittest
+import urllib
 from unittest.mock import patch
+from urllib.error import HTTPError
+
 import pytest
 
-from fake_useragent import errors, settings, utils
-from fake_useragent.utils import urlopen_has_ssl_context
+from fake_useragent import errors, utils
 from tests.utils import _request
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,3 @@
-import os
 import socket
 from urllib.request import Request
 

--- a/tox.ini
+++ b/tox.ini
@@ -5,20 +5,13 @@ envlist =
 isolated_build = True
 skip_missing_interpreters = True
 
-[isort]
-profile = black
-multi_line_output = 3
-
 [testenv]
 deps =
     black
-    isort
     pytest
     pytest-cov
     validate-pyproject
 commands =
     black --check --diff .
-    # Isort needs to be fixed (skip is not recognized anymore)
-    # isort --check-only -rc fake_useragent --diff
     validate-pyproject pyproject.toml
     pytest {posargs}


### PR DESCRIPTION
[Ruff](https://beta.ruff.rs/) supports [over 500 lint rules](https://beta.ruff.rs/docs/rules) including bandit, isort, pylint, pyupgrade, and flake8 plus its plugins, and is written in Rust for speed.

The `ruff` Action uses minimal steps to run in ~10 seconds, rapidly providing intuitive GitHub Annotations to contributors.

![image](https://user-images.githubusercontent.com/3709715/223758136-afc386d2-70aa-4eff-953a-2c2d82ceea23.png)

Moves `isort` out of `tox.ini` and into `ruff` and `pyproject.toml`.
Now when you want to fix imports, just do `ruff --select="I" --fix.`