### PR TITLE
Return whole object methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,11 +92,11 @@ _Hint:_ Of-course you can **combine all those arguments** to you liking!
 Since version 1.3.0 we now also offer you the following "get" properties which return the whole Python dictionary of the UA, instead of only the user-agent string:
 
 > **Warning**
-> Raw JSON object "as is" (in a Python dictionary) is returned.
-> This data structure could change in the future!
+> Raw JSON objects (in a Python dictionaries) are returned "as is".
+> Meaning, this data structure could change in the future!
 >
 > Be aware that these "get" properties below might not return the same key/value pairs in the future.
-> Use `ua.random` or alike, if you want to use a stable interface.
+> Use `ua.random` or alike as mentioned above, if you want to use a stable interface.
 
 ```py
 from fake_useragent import UserAgent

--- a/README.md
+++ b/README.md
@@ -163,10 +163,10 @@ Make sure that you using latest version!
 pip install --upgrade fake-useragent
 ```
 
-Or if that isn't working, try to install the latest package version like this (`1.2.0` is an example, check what the [latest version is on PyPi](https://pypi.org/project/fake-useragent/#history)):
+Or if that isn't working, try to install the latest package version like this (`1.3.0` is an example, check what the [latest version is on PyPi](https://pypi.org/project/fake-useragent/#history)):
 
 ```sh
-pip install fake-useragent==1.2.0
+pip install fake-useragent==1.3.0
 ```
 
 Check version via the Python console:

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Up-to-date simple useragent faker with real world database.
 
 - Data is pre-downloaded from [techblog.willshouse.com](https://techblog.willshouse.com/2012/01/03/most-common-user-agents/) and the data is part of the package
 - Retrieves user-agent strings locally
+- Retrieve user-agent Python dictionary
 - Supports Python 3.x
 
 ### Installation

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ pip3 install fake-useragent
 
 ### Usage
 
-Simple usage example, see below for more examples:
+Simple usage examples below, see also next chapters in this readme for more advanced usages:
 
 ```py
 from fake_useragent import UserAgent
@@ -86,6 +86,37 @@ ua.random
 ```
 
 _Hint:_ Of-course you can **combine all those arguments** to you liking!
+
+#### User-agent Python Dictionary
+
+Since version 1.3.0 we now also offer you the following "get" properties which return the whole Python dictionary of the UA, instead of only the user-agent string:
+
+> **Warning**
+> Raw JSON object "as is" (in a Python dictionary) is returned.
+> This data structure could change in the future!
+>
+> Be aware that these "get" properties below might not return the same key/value pairs in the future.
+> Use `ua.random` or alike, if you want to use a stable interface.
+
+```py
+from fake_useragent import UserAgent
+ua = UserAgent()
+
+# Random user-agent dictionary (object)
+ua.getRandom
+# {'percent': 0.8, 'useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Safari/537.36 Edg/116.0.1938.76', 'system': 'Edge 116.0 Win10', 'browser': 'edge', 'version': 116.0, 'os': 'win10'}
+
+# More get properties:
+ua.getFirefox
+# {'percent': 0.3, 'useragent': 'Mozilla/5.0 (Windows NT 10.0; rv:109.0) Gecko/20100101 Firefox/118.0', 'system': 'Firefox 118.0 Win10', 'browser': 'firefox', 'version': 118.0, 'os': 'win10'}
+ua.getChrome
+ua.getSafari
+ua.getEdge
+
+# And a method with an argument.
+# This is exactly the same as using: ua.getFirefox
+ua.getBrowser('firefox')
+```
 
 ### Notes
 
@@ -193,6 +224,15 @@ black .
 ```
 
 ### Changelog
+
+- 1.3.0 October 2, 2023
+
+  - Introducing new `ua.getRandom`, `ua.getFirefox`, `ua.getChrome`, `ua.getSafari`. And a generic method: `ua.getBrowser(..)` (eg. `getBrowser('firefox')`)
+    - These new properties above allows you to retrieve the whole raw Python dictionary, instead of only the UA string.
+    - These properties might return different key/values pairs in the future!
+  - Fix the `os` argument 'windows' to check for both `win10`and `win7` values (previously only checking on `win10`), thus returning more UAs
+  - Improved user-agent scraper (now also containing Safari browser again)
+  - Updated browsers.json data file
 
 - 1.2.1 August 2, 2023
 

--- a/cache_scraper/useragentscraper/spiders/useragent.py
+++ b/cache_scraper/useragentscraper/spiders/useragent.py
@@ -20,10 +20,7 @@ class UserAgentSpider(scrapy.Spider):
         for agent in agents:
             try:
                 system_splitted = agent["system"].split()
-                if len(system_splitted) > 3:
-                    [browser, version, os] = agent["system"].split()
-                else:
-                    [browser, version, os] = agent["system"].split()
+                [browser, version, os] = agent["system"].split()
                 # Remove percentage icon & convert to float
                 agent["percent"] = float(agent["percent"][:-1])
                 # Add additional fields
@@ -36,7 +33,7 @@ class UserAgentSpider(scrapy.Spider):
                 agent["os"] = os.lower()  # To lower-case
                 # Yield each agent object at the time
                 yield agent
-            except ValueError as e:
+            except ValueError:
                 # Ignore user-agent strings that could not be parsed (eg. bot agent strings)
                 # (eg. bot agent strings like headless chrome, but also Yandex Browser and iOS)
                 pass

--- a/cache_scraper/useragentscraper/spiders/useragent.py
+++ b/cache_scraper/useragentscraper/spiders/useragent.py
@@ -19,7 +19,6 @@ class UserAgentSpider(scrapy.Spider):
 
         for agent in agents:
             try:
-                system_splitted = agent["system"].split()
                 [browser, version, os] = agent["system"].split()
                 # Remove percentage icon & convert to float
                 agent["percent"] = float(agent["percent"][:-1])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fake-useragent"
-version = "1.2.1"
+version = "1.3.0"
 authors = [
     {name = "Victor Kovtun", email = "hellysmile@gmail.com"},
     {name = "Melroy van den Berg", email = "melroy@melroy.org"},

--- a/src/fake_useragent/fake.py
+++ b/src/fake_useragent/fake.py
@@ -94,7 +94,7 @@ class FakeUserAgent:
 
             # Pick a random browser user-agent from the filtered browsers
             # And return the full dict
-            return random.choice(filtered_browsers)
+            return random.choice(filtered_browsers) # noqa: S311
         except (KeyError, IndexError):
             if self.fallback is None:
                 raise FakeUserAgentError(

--- a/src/fake_useragent/fake.py
+++ b/src/fake_useragent/fake.py
@@ -94,7 +94,7 @@ class FakeUserAgent:
 
             # Pick a random browser user-agent from the filtered browsers
             # And return the full dict
-            return random.choice(filtered_browsers) # noqa: S311
+            return random.choice(filtered_browsers)  # noqa: S311
         except (KeyError, IndexError):
             if self.fallback is None:
                 raise FakeUserAgentError(

--- a/src/fake_useragent/settings.py
+++ b/src/fake_useragent/settings.py
@@ -12,7 +12,7 @@ REPLACEMENTS = {
 }
 
 OS_REPLACEMENTS = {
-    "windows": "win10",
+    "windows": ["win10", "win7"],
 }
 
 SHORTCUTS = {

--- a/tests/test_fake.py
+++ b/tests/test_fake.py
@@ -73,7 +73,8 @@ class TestFake(unittest.TestCase):
         fallback = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36"
 
         ua = UserAgent()
-        self.assertEqual(ua.getBrowser("non_existing"), fallback)
+        self.assertIsInstance(ua.getBrowser("non_existing"), dict)
+        self.assertEqual(ua.getBrowser("non_existing").get("useragent"), fallback)
 
     def test_fake_fallback_str_types(self):
         with pytest.raises(AssertionError):

--- a/tests/test_fake.py
+++ b/tests/test_fake.py
@@ -73,7 +73,7 @@ class TestFake(unittest.TestCase):
         fallback = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36"
 
         ua = UserAgent()
-        self.assertEqual(ua.getBrowser('non_existing'), fallback)
+        self.assertEqual(ua.getBrowser("non_existing"), fallback)
 
     def test_fake_fallback_str_types(self):
         with pytest.raises(AssertionError):

--- a/tests/test_fake.py
+++ b/tests/test_fake.py
@@ -28,6 +28,17 @@ class TestFake(unittest.TestCase):
         self.assertTrue(ua.random)
         self.assertIsInstance(ua.random, str)
 
+        self.assertTrue(ua.getChrome)
+        self.assertIsInstance(ua.getChrome, dict)
+        self.assertTrue(ua.getEdge)
+        self.assertIsInstance(ua.getEdge, dict)
+        self.assertTrue(ua.getFirefox)
+        self.assertIsInstance(ua.getFirefox, dict)
+        self.assertTrue(ua.getSafari)
+        self.assertIsInstance(ua.getSafari, dict)
+        self.assertTrue(ua.getRandom)
+        self.assertIsInstance(ua.getRandom, dict)
+
     def test_fake_probe_user_agent_browsers(self):
         ua = UserAgent()
         ua.edge  # noqa: B018
@@ -41,6 +52,11 @@ class TestFake(unittest.TestCase):
         ua.safari  # noqa: B018
         ua.random  # noqa: B018
         ua["random"]  # noqa: B018
+        ua.getEdge  # noqa: B018
+        ua.getChrome  # noqa: B018
+        ua.getFirefox  # noqa: B018
+        ua.getSafari  # noqa: B018
+        ua.getRandom  # noqa: B018
 
     def test_fake_data_browser_type(self):
         ua = UserAgent()
@@ -52,6 +68,12 @@ class TestFake(unittest.TestCase):
         ua = UserAgent()
         self.assertEqual(ua.non_existing, fallback)
         self.assertEqual(ua["non_existing"], fallback)
+
+    def test_fake_fallback_dictionary(self):
+        fallback = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36"
+
+        ua = UserAgent()
+        self.assertEqual(ua.getBrowser('non_existing'), fallback)
 
     def test_fake_fallback_str_types(self):
         with pytest.raises(AssertionError):


### PR DESCRIPTION
Add additional get calls, which will return the whole object. Plus new test-cases.

Bug Fix: Include also win7 when using the windows input (which is default). Before you only got win10 UAs.

Fixes: #215

