### PR TITLE
python 3.12 support

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest # [macos-latest, windows-latest]
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "pypy-3.9"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "pypy-3.9"]
     name: Python ${{ matrix.python-version }} Test
     steps:
       - uses: actions/checkout@v3

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-addopts = -s --strict --keep-duplicates --cache-clear --verbose --maxfail=1 --no-cov-on-fail --cov=fake_useragent --cov-report=term --cov-report=xml --cov-report=html --fulltrace
+addopts = -s --strict-markers --keep-duplicates --cache-clear --verbose --maxfail=1 --no-cov-on-fail --cov=fake_useragent --cov-report=term --cov-report=xml --cov-report=html --fulltrace

--- a/src/fake_useragent/utils.py
+++ b/src/fake_useragent/utils.py
@@ -9,19 +9,13 @@ else:
 
 from fake_useragent.log import logger
 
-# Fallback method for retrieving data file
-try:
-    from pkg_resources import resource_filename
-except ImportError:
-    pass
-
 str_types = (str,)
 
 
 # Load all lines from browser.json file
 # Returns array of objects
 def load():
-    data = []
+    data, ret = [], None
     try:
         json_lines = (
             ilr.files("fake_useragent.data").joinpath("browsers.json").read_text()
@@ -37,6 +31,8 @@ def load():
             exc_info=exc,
         )
         try:
+            from pkg_resources import resource_filename
+
             with open(
                 resource_filename("fake_useragent", "data/browsers.json")
             ) as file:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -27,7 +27,9 @@ class TestUtils(unittest.TestCase):
         self.assertIsInstance(data[0]["useragent"], str)
 
     # https://github.com/python/cpython/issues/95299
-    @unittest.skipIf(sys.version_info >= (3, 12), "not compatible with Python 3.12 (or higher)")
+    @unittest.skipIf(
+        sys.version_info >= (3, 12), "not compatible with Python 3.12 (or higher)"
+    )
     def test_utils_load_pkg_resource_fallback(self):
         # By default use_local_file is also True during production
         # We will not allow the default importlib resources to be used, by triggering an Exception

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,7 +5,7 @@ if sys.version_info >= (3, 10):
 else:
     import importlib_resources as ilr
 
-import unittestImprove skip unit test
+import unittest
 from unittest.mock import patch
 
 from fake_useragent import utils

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -27,6 +27,10 @@ class TestUtils(unittest.TestCase):
         self.assertIsInstance(data[0]["useragent"], str)
 
     def test_utils_load_pkg_resource_fallback(self):
+        # https://github.com/python/cpython/issues/95299
+        if sys.version_info >= (3, 12):
+            return self.skipTest("This test is not supported on Python 3.12 or higher")
+
         # By default use_local_file is also True during production
         # We will not allow the default importlib resources to be used, by triggering an Exception
         with patch.object(ilr, "files") as mocked_importlib_resources_files:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,7 +5,7 @@ if sys.version_info >= (3, 10):
 else:
     import importlib_resources as ilr
 
-import unittest
+import unittestImprove skip unit test
 from unittest.mock import patch
 
 from fake_useragent import utils
@@ -26,11 +26,9 @@ class TestUtils(unittest.TestCase):
         self.assertIsInstance(data[0], object)
         self.assertIsInstance(data[0]["useragent"], str)
 
+    # https://github.com/python/cpython/issues/95299
+    @unittest.skipIf(sys.version_info >= (3, 12), "not compatible with Python 3.12 (or higher)")
     def test_utils_load_pkg_resource_fallback(self):
-        # https://github.com/python/cpython/issues/95299
-        if sys.version_info >= (3, 12):
-            return self.skipTest("This test is not supported on Python 3.12 or higher")
-
         # By default use_local_file is also True during production
         # We will not allow the default importlib resources to be used, by triggering an Exception
         with patch.object(ilr, "files") as mocked_importlib_resources_files:

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py3{8,9,10,11}
+    py3{8,9,10,11,12}
     pypy3
 isolated_build = True
 skip_missing_interpreters = True


### PR DESCRIPTION
Hi, I'm maintainer of [twscrape](https://github.com/vladkens/twscrape/) which uses fake-useragent inside. While updating my package to Python 3.12, I saw a deprecation warning in your package. In this PR I am correcting this.

Python core team removed setuptools in 3.12 and pkg_resource no available at now. So I skip test_utils_load_pkg_resource_fallback test for Python >= 3.12. Details: https://github.com/python/cpython/issues/95299

Thanks for great package.