### PR TITLE
Add Python 3.12 to the tests & Ignore warning + impove import in utils.py

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest # [macos-latest, windows-latest]
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "pypy-3.9"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "pypy-3.9"]
     name: Python ${{ matrix.python-version }} Test
     steps:
       - uses: actions/checkout@v3

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-addopts = -s --strict --keep-duplicates --cache-clear --verbose --maxfail=1 --no-cov-on-fail --cov=fake_useragent --cov-report=term --cov-report=xml --cov-report=html --fulltrace
+addopts = -s --strict-markers --keep-duplicates --cache-clear --verbose --maxfail=1 --no-cov-on-fail --cov=fake_useragent --cov-report=term --cov-report=xml --cov-report=html --fulltrace

--- a/src/fake_useragent/utils.py
+++ b/src/fake_useragent/utils.py
@@ -1,5 +1,8 @@
 import json
 import sys
+# Ignore warnings, we know we use deprecated methods on purpose for fallback behaviour
+import warnings
+warnings.filterwarnings("ignore")
 
 # We need files() from Python 3.10 or higher
 if sys.version_info >= (3, 10):

--- a/src/fake_useragent/utils.py
+++ b/src/fake_useragent/utils.py
@@ -1,7 +1,8 @@
 import json
 import sys
-# Ignore warnings, we know we use deprecated methods on purpose for fallback behaviour
 import warnings
+
+# Ignore warnings, we know we use deprecated methods on purpose for fallback behaviour
 warnings.filterwarnings("ignore")
 
 # We need files() from Python 3.10 or higher
@@ -12,19 +13,13 @@ else:
 
 from fake_useragent.log import logger
 
-# Fallback method for retrieving data file
-try:
-    from pkg_resources import resource_filename
-except ImportError:
-    pass
-
 str_types = (str,)
 
 
 # Load all lines from browser.json file
 # Returns array of objects
 def load():
-    data = []
+    data, ret = [], None
     try:
         json_lines = (
             ilr.files("fake_useragent.data").joinpath("browsers.json").read_text()
@@ -40,6 +35,9 @@ def load():
             exc_info=exc,
         )
         try:
+            # Fallback method for retrieving data file
+            from pkg_resources import resource_filename
+
             with open(
                 resource_filename("fake_useragent", "data/browsers.json")
             ) as file:

--- a/src/fake_useragent/utils.py
+++ b/src/fake_useragent/utils.py
@@ -1,8 +1,9 @@
 import json
 import sys
-import warnings
 
 # Ignore warnings, we know we use deprecated methods on purpose for fallback behaviour
+import warnings
+
 warnings.filterwarnings("ignore")
 
 # We need files() from Python 3.10 or higher
@@ -12,6 +13,12 @@ else:
     import importlib_resources as ilr
 
 from fake_useragent.log import logger
+
+# Fallback method for retrieving data file
+try:
+    from pkg_resources import resource_filename
+except ImportError:
+    pass
 
 str_types = (str,)
 
@@ -35,9 +42,6 @@ def load():
             exc_info=exc,
         )
         try:
-            # Fallback method for retrieving data file
-            from pkg_resources import resource_filename
-
             with open(
                 resource_filename("fake_useragent", "data/browsers.json")
             ) as file:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -26,6 +26,7 @@ class TestUtils(unittest.TestCase):
         self.assertIsInstance(data[0], object)
         self.assertIsInstance(data[0]["useragent"], str)
 
+    @unittest.skipIf(sys.version_info >= (3, 12), "not compatible with Python 3.12 (or higher)")
     def test_utils_load_pkg_resource_fallback(self):
         # By default use_local_file is also True during production
         # We will not allow the default importlib resources to be used, by triggering an Exception

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py3{8,9,10,11}
+    py3{8,9,10,11,12}
     pypy3
 isolated_build = True
 skip_missing_interpreters = True


### PR DESCRIPTION
- Add Python 3.12 to the test runs
- Ignore all warnings in utils.py, yes we are aware of these deprecated methods these are used for fallback behavior. 
- Improved addopts parameter
- Fix initialization of parameters 