### PR TITLE
Upgrade github actions

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -41,9 +41,9 @@ jobs:
     runs-on: ubuntu-latest
     name: Build & deploy to PyPi
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.x"
       - name: Install dependencies

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Upload code coverage (HTML)
         uses: actions/upload-artifact@v4
         with:
-          name: code-coverage
+          name: code-coverage-${{ matrix.python-version }}
           path: htmlcov/
 
   build_and_deploy:

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -16,12 +16,12 @@ jobs:
     runs-on: ubuntu-latest # [macos-latest, windows-latest]
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "pypy-3.9"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "pypy-3.9"]
     name: Python ${{ matrix.python-version }} Test
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           check-latest: true
@@ -31,7 +31,7 @@ jobs:
       - name: Run tests + lint check
         run: tox
       - name: Upload code coverage (HTML)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: code-coverage
           path: htmlcov/

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,7 +18,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,10 +20,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@v3
         with:
           languages: python
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@v3
         with:
           category: "/language:python"

--- a/.github/workflows/dependabot_auto_merge.yml
+++ b/.github/workflows/dependabot_auto_merge.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v1
+        uses: dependabot/fetch-metadata@v2
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Approve a PR

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -12,7 +12,7 @@ jobs:
   ruff-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install dependencies
         run: pip install -r requirements.txt
       - name: Ruff Check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ Homepage = "https://github.com/fake-useragent/fake-useragent"
 line-length = 142
 lint.select = ["B", "C4", "C9", "E", "F", "I", "PL", "S", "SIM", "U", "W", "YTT"]
 lint.ignore = ["B904", "C408", "PLW2901", "SIM105", "SIM108"]
-target-version = "py37"
+target-version = "py39"
 
 [tool.ruff.lint.isort]
 known-first-party = ["fake_useragent"]


### PR DESCRIPTION
- Update GitHub Actions Actions (yes I know confusing name of GitHub). These are the actions you see with `uses: ...`
- Update `target-version` Ruff to py39 (both 3.7 and 3.8 are soon EOL or already EOL)
- Also update the test matrix in action.yml as well