### PR TITLE
Add basic type hints to the whole package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,3 +73,4 @@ zip-safe = false
 
 [tool.setuptools.package-data]
 "fake_useragent.data" = ["*.json"]
+"fake_useragent" = ["py.typed"]

--- a/src/fake_useragent/fake.py
+++ b/src/fake_useragent/fake.py
@@ -1,24 +1,25 @@
 import random
+from typing import Any, Union
 
 from fake_useragent import settings
 from fake_useragent.log import logger
-from fake_useragent.utils import load, str_types
+from fake_useragent.utils import BrowserUserAgentData, load, str_types
 
 
 class FakeUserAgent:
     def __init__(  # noqa: PLR0913
         self,
-        browsers=["chrome", "edge", "firefox", "safari"],
-        os=["windows", "macos", "linux", "android", "ios"],
-        min_version=0.0,
-        min_percentage=0.0,
-        platforms=["pc", "mobile", "tablet"],
-        fallback=(
+        browsers: Union[list[str], str] = ["chrome", "edge", "firefox", "safari"],
+        os: Union[list[str], str] = ["windows", "macos", "linux", "android", "ios"],
+        min_version: float = 0.0,
+        min_percentage: float = 0.0,
+        platforms: Union[list[str], str] = ["pc", "mobile", "tablet"],
+        fallback: str = (
             "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
             "AppleWebKit/537.36 (KHTML, like Gecko) "
             "Chrome/122.0.0.0 Safari/537.36 Edg/122.0.0.0"
         ),
-        safe_attrs=tuple(),
+        safe_attrs: Union[tuple[str], list[str], set[str]] = tuple(),
     ):
         # Check inputs
         assert isinstance(browsers, (list, str)), "browsers must be list or string"
@@ -30,7 +31,7 @@ class FakeUserAgent:
         if isinstance(os, str):
             os = [os]
         # OS replacement (windows -> [win10, win7])
-        self.os = []
+        self.os: list[str] = []
         for os_name in os:
             if os_name in settings.OS_REPLACEMENTS:
                 self.os.extend(settings.OS_REPLACEMENTS[os_name])
@@ -54,7 +55,7 @@ class FakeUserAgent:
         assert isinstance(platforms, (list, str)), "platforms must be list or string"
         if isinstance(platforms, str):
             platforms = [platforms]
-        self.platforms = platforms
+        self.platforms: list[str] = platforms
 
         assert isinstance(fallback, str), "fallback must be string"
         self.fallback = fallback
@@ -69,14 +70,16 @@ class FakeUserAgent:
             assert all(
                 str_types_safe_attrs
             ), "safe_attrs must be list\\tuple\\set of strings or unicode"
-        self.safe_attrs = set(safe_attrs)
+        self.safe_attrs: set[str] = set(safe_attrs)
 
         # Next, load our local data file into memory (browsers.json)
         self.data_browsers = load()
 
     # This method will return a filtered list of user agents.
     # The request parameter can be used to specify a browser.
-    def _filter_useragents(self, request=None):
+    def _filter_useragents(
+        self, request: Union[str, None] = None
+    ) -> list[BrowserUserAgentData]:
         # filter based on browser, os, platform and version.
         filtered_useragents = list(
             filter(
@@ -98,7 +101,7 @@ class FakeUserAgent:
 
     # This method will return an object
     # Usage: ua.getBrowser('firefox')
-    def getBrowser(self, request):
+    def getBrowser(self, request: str) -> BrowserUserAgentData:
         try:
             # Handle request value
             for value, replacement in settings.REPLACEMENTS.items():
@@ -130,6 +133,8 @@ class FakeUserAgent:
             # Return fallback object
             return {
                 "useragent": self.fallback,
+                "percent": 100.0,
+                "type": "pc",
                 "system": "Chrome 122.0 Win10",
                 "browser": "chrome",
                 "version": 122.0,
@@ -138,12 +143,12 @@ class FakeUserAgent:
 
     # This method will use the method below, returning a string
     # Usage: ua['random']
-    def __getitem__(self, attr):
+    def __getitem__(self, attr: str) -> Union[str, Any]:
         return self.__getattr__(attr)
 
     # This method will returns a string
     # Usage: ua.random
-    def __getattr__(self, attr):
+    def __getattr__(self, attr: str) -> Union[str, Any]:
         if attr in self.safe_attrs:
             return super(UserAgent, self).__getattribute__(attr)
 
@@ -178,52 +183,52 @@ class FakeUserAgent:
             return self.fallback
 
     @property
-    def chrome(self):
+    def chrome(self) -> str:
         return self.__getattr__("chrome")
 
     @property
-    def googlechrome(self):
+    def googlechrome(self) -> str:
         return self.chrome
 
     @property
-    def edge(self):
+    def edge(self) -> str:
         return self.__getattr__("edge")
 
     @property
-    def firefox(self):
+    def firefox(self) -> str:
         return self.__getattr__("firefox")
 
     @property
-    def ff(self):
+    def ff(self) -> str:
         return self.firefox
 
     @property
-    def safari(self):
+    def safari(self) -> str:
         return self.__getattr__("safari")
 
     @property
-    def random(self):
+    def random(self) -> str:
         return self.__getattr__("random")
 
     # The following 'get' methods return an object rather than only the UA string
     @property
-    def getFirefox(self):
+    def getFirefox(self) -> BrowserUserAgentData:
         return self.getBrowser("firefox")
 
     @property
-    def getChrome(self):
+    def getChrome(self) -> BrowserUserAgentData:
         return self.getBrowser("chrome")
 
     @property
-    def getEdge(self):
+    def getEdge(self) -> BrowserUserAgentData:
         return self.getBrowser("edge")
 
     @property
-    def getSafari(self):
+    def getSafari(self) -> BrowserUserAgentData:
         return self.getBrowser("safari")
 
     @property
-    def getRandom(self):
+    def getRandom(self) -> BrowserUserAgentData:
         return self.getBrowser("random")
 
 

--- a/src/fake_useragent/utils.py
+++ b/src/fake_useragent/utils.py
@@ -1,5 +1,7 @@
 import json
 import sys
+from enum import Enum
+from typing import TypedDict, Union
 
 # We need files() from Python 3.10 or higher
 if sys.version_info >= (3, 10):
@@ -13,10 +15,28 @@ from fake_useragent.log import logger
 str_types = (str,)
 
 
+class BrowserUserAgentData(TypedDict):
+    useragent: str
+    """The useragent string."""
+    percent: float
+    """Sampling probability for this useragent when random sampling. Currently has no effect."""
+    type: str
+    """The device type for this useragent."""
+    system: str
+    """System name for the useragent."""
+    browser: str
+    """Browser name for the useragent."""
+    version: float
+    """Version of the browser."""
+    os: str
+    """OS name for the useragent."""
+
+
 # Load all lines from browser.json file
 # Returns array of objects
-def load():
-    data, ret = [], None
+def load() -> list[BrowserUserAgentData]:
+    data = []
+    ret: Union[list[BrowserUserAgentData], None] = None
     try:
         json_lines = (
             ilr.files("fake_useragent.data").joinpath("browsers.json").read_text()

--- a/src/fake_useragent/utils.py
+++ b/src/fake_useragent/utils.py
@@ -16,19 +16,19 @@ str_types = (str,)
 
 class BrowserUserAgentData(TypedDict):
     useragent: str
-    """The useragent string."""
+    """The user agent string."""
     percent: float
     """Sampling probability for this useragent when random sampling. Currently has no effect."""
     type: str
-    """The device type for this useragent."""
+    """The device type for this user agent."""
     system: str
-    """System name for the useragent."""
+    """System name for the user agent."""
     browser: str
-    """Browser name for the useragent."""
+    """Browser name for the user agent."""
     version: float
     """Version of the browser."""
     os: str
-    """OS name for the useragent."""
+    """OS name for the user agent."""
 
 
 # Load all lines from browser.json file

--- a/src/fake_useragent/utils.py
+++ b/src/fake_useragent/utils.py
@@ -18,7 +18,7 @@ class BrowserUserAgentData(TypedDict):
     useragent: str
     """The user agent string."""
     percent: float
-    """Sampling probability for this useragent when random sampling. Currently has no effect."""
+    """Sampling probability for this user agent when random sampling. Currently has no effect."""
     type: str
     """The device type for this user agent."""
     system: str

--- a/src/fake_useragent/utils.py
+++ b/src/fake_useragent/utils.py
@@ -1,6 +1,5 @@
 import json
 import sys
-from enum import Enum
 from typing import TypedDict, Union
 
 # We need files() from Python 3.10 or higher


### PR DESCRIPTION
# Summary
This PR adds basic type-hints to the whole package. Closes #344.

# Questions
1. Why are there 2 imports _at the bottom_ of `utils.py`? I tried removing the unused `settings` import and moving the `FakeUserAgentError` to the top and tests passed.
2. There are checks to see if `self.fallback is None` [[1](https://github.com/fake-useragent/fake-useragent/blob/88645b5fdbd1624229cdee6f7b809d56627d5d61/src/fake_useragent/fake.py#L127), [2](https://github.com/fake-useragent/fake-useragent/blob/88645b5fdbd1624229cdee6f7b809d56627d5d61/src/fake_useragent/fake.py#L180)] but, by construction, it can only be a `str` [[3](https://github.com/fake-useragent/fake-useragent/blob/88645b5fdbd1624229cdee6f7b809d56627d5d61/src/fake_useragent/fake.py#L60)]. Shuold we type-hint it `str | None` and change the `assert`ion or should the code checking against `None` be changed?
3. What is the "system" key in the data, so that we can add better docstrings?
4. What's the point of `str_types`? I currently type-hint `fallback` as `set[str]` when it should really be a `set` of members of that `tuple`. I can look into it if we want to keep that :).
5. The `str, Enum`s I added might be a bit much. I like them because they are self-documenting and because they inherit from `str, Enum`, members are `str`s, so that's transparent to the user. However, it might be too much of a burden to remember to add elements to the `Enum` when changing the `JSON`. What do you think?

# Notes
If this PR is merged, I wouldn't do a release yet. There are some changes I'd like to propose regarding the defaults and asserts, but I'll be opening new issues for those so you can decide what you prefer! 