### PR TITLE
Finish deprecating Python 3.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,13 +6,10 @@ build-backend = "setuptools.build_meta"
 name = "fake-useragent"
 version = "1.5.1"
 authors = [
-    {name = "Melroy van den Berg", email = "melroy@melroy.org"},
-    {name = "Victor Kovtun", email = "hellysmile@gmail.com"}
+    { name = "Melroy van den Berg", email = "melroy@melroy.org" },
+    { name = "Victor Kovtun", email = "hellysmile@gmail.com" },
 ]
-dependencies = [
-    "importlib-resources >= 5.0; python_version < '3.10'",
-    "importlib-metadata ~= 4.0; python_version < '3.8'",
-]
+dependencies = ["importlib-resources >= 5.0; python_version < '3.10'"]
 description = "Up-to-date simple useragent faker with real world database"
 keywords = [
     "user",
@@ -49,7 +46,20 @@ Homepage = "https://github.com/fake-useragent/fake-useragent"
 
 [tool.ruff]
 line-length = 142
-lint.select = ["B", "C4", "C9", "E", "F", "I", "PL", "S", "SIM", "U", "W", "YTT"]
+lint.select = [
+    "B",
+    "C4",
+    "C9",
+    "E",
+    "F",
+    "I",
+    "PL",
+    "S",
+    "SIM",
+    "U",
+    "W",
+    "YTT",
+]
 lint.ignore = ["B904", "C408", "PLW2901", "SIM105", "SIM108"]
 target-version = "py39"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,6 @@ distlib==0.3.8
 exceptiongroup==1.2.2
 fastjsonschema==2.20.0
 filelock==3.16.1
-importlib-metadata==8.5.0
 importlib-resources==6.4.5
 iniconfig==2.0.0
 isort==5.13.2

--- a/src/fake_useragent/settings.py
+++ b/src/fake_useragent/settings.py
@@ -1,8 +1,4 @@
-try:
-    from importlib import metadata
-except ImportError:
-    # Running on pre-3.8 Python; use importlib-metadata package
-    import importlib_metadata as metadata
+from importlib import metadata
 
 __version__ = metadata.version("fake-useragent")
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py3{8,9,10,11,12}
+    py3{9,10,11,12}
     pypy3
 isolated_build = True
 skip_missing_interpreters = True


### PR DESCRIPTION
#345 deprecated Python 3.8, but some remnants are still in `main`. This PR removes Python 3.8 from the rest of the repo.

Ran tests with `tox` and they passed. Line `dependencies = ["importlib-resources >= 5.0; python_version < '3.10'"]` can be removed once we deprecate `3.9` support in the (probably) distant future.