### PR TITLE
Fix and improve ruff configs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,20 +46,7 @@ Homepage = "https://github.com/fake-useragent/fake-useragent"
 
 [tool.ruff]
 line-length = 142
-lint.select = [
-    "B",
-    "C4",
-    "C9",
-    "E",
-    "F",
-    "I",
-    "PL",
-    "S",
-    "SIM",
-    "U",
-    "W",
-    "YTT",
-]
+lint.select = ["B", "C4", "C9", "E", "F", "I", "PL", "S", "SIM", "W", "YTT"]
 lint.ignore = ["B904", "C408", "PLW2901", "SIM105", "SIM108"]
 target-version = "py39"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,6 @@ max-complexity = 13
 
 [tool.ruff.lint.per-file-ignores]
 "src/fake_useragent/__init__.py" = ["F401"]
-"src/fake_useragent/fake.py" = ["B006", "S101"]
 "tests/*" = ["S", "SIM", "UP015"]
 
 [tool.ruff.lint.pylint]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ max-complexity = 13
 
 [tool.ruff.lint.per-file-ignores]
 "src/fake_useragent/__init__.py" = ["F401"]
-"tests/*" = ["S", "SIM", "UP015"]
+"tests/**/*" = ["S", "SIM", "UP015"]
 
 [tool.ruff.lint.pylint]
 max-args = 7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,10 +45,13 @@ content-type = "text/markdown"
 Homepage = "https://github.com/fake-useragent/fake-useragent"
 
 [tool.ruff]
-line-length = 142
-lint.select = ["B", "C4", "C9", "E", "F", "I", "PL", "S", "SIM", "W", "YTT"]
-lint.ignore = ["B904", "C408", "PLW2901", "SIM105", "SIM108"]
 target-version = "py39"
+line-length = 142
+
+[tool.ruff.lint]
+select = ["B", "C4", "C9", "E", "F", "I", "PL", "S", "SIM", "W", "YTT"]
+
+ignore = ["B904", "C408", "PLW2901", "SIM105", "SIM108"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["fake_useragent"]


### PR DESCRIPTION
# Summary
This PR applies some fixes and/or general improvements to ruff configs:
- Remove the `U` rule, which isn't an active rule today (close #363).
- Group select/ignore settings under a single `tool.ruff.lint` key.
- Remove `B006` and `S101` ignores on `fake.py`. Both fixed on #357.
- Ensure `per-file-ignores` for tests apply recursively, which includes the "tests" package (as otherwise, enabling `D` rules would require documenting tests even if added to the per-file-ignore).

# Note
As usual, please make any comments you deem necessary. This PR has commits I wouldn't consider "mandatory", which we can drop if you feel so inclined. Just let me know!