### PR TITLE
Specify `__all__` in `__init__.py` to fix pyright support

### DIFF
--- a/src/fake_useragent/__init__.py
+++ b/src/fake_useragent/__init__.py
@@ -3,3 +3,11 @@
 from fake_useragent.errors import FakeUserAgentError, UserAgentError
 from fake_useragent.fake import FakeUserAgent, UserAgent
 from fake_useragent.get_version import __version__
+
+__all__ = [
+    "FakeUserAgent",
+    "UserAgent",
+    "FakeUserAgentError",
+    "UserAgentError",
+    "__version__",
+]


### PR DESCRIPTION
- In https://github.com/fake-useragent/fake-useragent/pull/346

@sebastian-correa added a `py.typed` file in this module, but didn't specify `__all__` in `__init__.py`, which makes `pyright` complaining about

```
error: "UserAgent" is not exported from module "fake_useragent"
    Import from "fake_useragent.fake" instead (reportPrivateImportUsage)
```

This pull request includes a small change to the `src/fake_useragent/__init__.py` file, which adds an `__all__` list to define the public API of the module.

* [`src/fake_useragent/__init__.py`](diffhunk://#diff-2bcdbaaf450ae44257d5d328d20429dfec654c069449b1a96a4156b558d70d7aR6-R7): Added `__all__` list to specify which names are public and should be exported when the module is imported.