### PR TITLE
Optimize jsonl data loading

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
     { name = "Victor Kovtun", email = "hellysmile@gmail.com" },
 ]
 requires-python = ">=3.9"
-dependencies = ["importlib-resources >= 6.0"]
+dependencies = []
 description = "Up-to-date simple useragent faker with real world database"
 keywords = [
     "user",

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,6 @@ distlib==0.3.9
 exceptiongroup==1.2.2
 fastjsonschema==2.20.0
 filelock==3.16.1
-importlib-resources==6.4.5
 iniconfig==2.0.0
 isort==5.13.2
 mypy-extensions==1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ pep517==0.13.1
 platformdirs==4.3.6
 pluggy==1.5.0
 py==1.11.0
+pydantic==2.10.3
 pyparsing==3.2.0
 pyproject-api==1.6.1
 pyproject_hooks==1.2.0

--- a/src/fake_useragent/utils.py
+++ b/src/fake_useragent/utils.py
@@ -47,6 +47,7 @@ def load() -> list[BrowserUserAgentData]:
         jsonl = get_data(__package__ or "fake_useragent", "data/browsers.jsonl")
         if jsonl is None:
             raise FakeUserAgentError("Failed to find browsers.jsonl")
+        # Convert JSONL to single big JSON list to speed up loading by ~2x.
         comma_joined_objects = jsonl.rstrip().decode().replace("\n", ",")
         json_list_string = f"[{comma_joined_objects}]"
         return json.loads(json_list_string)

--- a/src/fake_useragent/utils.py
+++ b/src/fake_useragent/utils.py
@@ -44,13 +44,16 @@ def load() -> list[BrowserUserAgentData]:
             `BrowserUserAgentData` schema.
     """
     path = Path(__file__, "../data/browsers.jsonl").resolve()
-    if not path.is_file():
-        raise FakeUserAgentError(f"Could not find the user agent data file at {path}")
-
     try:
-        json_lines = path.read_text()
-        return list(map(json.loads, json_lines.splitlines()))
+        with path.open() as f:
+            return list(map(json.loads, f))
     except Exception as exc:
-        logger.warning("Could not parse the contents.", exc_info=exc)
+        if not path.is_file():
+            logger.warning(
+                f"Could not find the user agent data file at {path}",
+                exc_info=exc,
+            )
+        else:
+            logger.warning("Could not parse the contents.", exc_info=exc)
 
     raise FakeUserAgentError("Failed to load the user agent data.")

--- a/src/fake_useragent/utils.py
+++ b/src/fake_useragent/utils.py
@@ -44,9 +44,10 @@ def load() -> list[BrowserUserAgentData]:
             `BrowserUserAgentData` schema.
     """
     try:
-        return json.loads(
-            f"[{get_data('fake_useragent', 'data/browsers.jsonl').rstrip().decode().replace(chr(10), ',')}]"
-        )
+        jsonl = get_data(__package__, "data/browsers.jsonl").rstrip().decode()
+        comma_joined_objects = jsonl.replace("\n", ",")
+        json_list_string = f"[{comma_joined_objects}]"
+        return json.loads(json_list_string)
     except Exception as exc:
         logger.warning("Could not find the user agent data file.", exc_info=exc)
     raise FakeUserAgentError("Failed to load the user agent data.")

--- a/src/fake_useragent/utils.py
+++ b/src/fake_useragent/utils.py
@@ -2,7 +2,7 @@
 
 import json
 from pkgutil import get_data
-from typing import TypedDict, Union
+from typing import Optional, TypedDict
 
 from fake_useragent.errors import FakeUserAgentError
 from fake_useragent.log import logger
@@ -17,17 +17,17 @@ class BrowserUserAgentData(TypedDict):
     """The usage percentage of the user agent."""
     type: str
     """The device type for this user agent (eg. mobile or desktop)."""
-    device_brand: Union[str, None]
+    device_brand: Optional[str]
     """Brand name for the device (eg. Generic_Android)."""
-    browser: Union[str, None]
+    browser: Optional[str]
     """Browser name for the user agent (eg. Chrome Mobile)."""
     browser_version: str
     """Version of the browser (eg. "100.0.4896.60")."""
     browser_version_major_minor: float
     """Major and minor version of the browser (eg. 100.0)."""
-    os: Union[str, None]
+    os: Optional[str]
     """OS name for the user agent (eg. Android)."""
-    os_version: Union[str, None]
+    os_version: Optional[str]
     """OS version (eg. 10)."""
     platform: str
     """Platform for the user agent (eg. Linux armv81)."""

--- a/src/fake_useragent/utils.py
+++ b/src/fake_useragent/utils.py
@@ -45,7 +45,7 @@ def load() -> list[BrowserUserAgentData]:
     """
     path = Path(__file__, "../data/browsers.jsonl").resolve()
     try:
-        return json.loads(f"[{path.read_text().rstrip().replace('\n', ',')}]")
+        return json.loads(f"[{path.read_text().rstrip().replace(chr(10), ',')}]")
     except Exception as exc:
         if not path.is_file():
             logger.warning(

--- a/src/fake_useragent/utils.py
+++ b/src/fake_useragent/utils.py
@@ -1,7 +1,7 @@
 """General utils for the fake_useragent package."""
 
 import json
-from pathlib import Path
+from pkgutil import get_data
 from typing import TypedDict
 
 from fake_useragent.errors import FakeUserAgentError
@@ -43,16 +43,10 @@ def load() -> list[BrowserUserAgentData]:
         list[BrowserUserAgentData]: The list of browser user agent data, following the
             `BrowserUserAgentData` schema.
     """
-    path = Path(__file__, "../data/browsers.jsonl").resolve()
     try:
-        return json.loads(f"[{path.read_text().rstrip().replace(chr(10), ',')}]")
+        return json.loads(
+            f"[{get_data('fake_useragent', 'data/browsers.jsonl').rstrip().decode().replace(chr(10), ',')}]"
+        )
     except Exception as exc:
-        if not path.is_file():
-            logger.warning(
-                f"Could not find the user agent data file at {path}",
-                exc_info=exc,
-            )
-        else:
-            logger.warning("Could not parse the contents.", exc_info=exc)
-
+        logger.warning("Could not find the user agent data file.", exc_info=exc)
     raise FakeUserAgentError("Failed to load the user agent data.")

--- a/src/fake_useragent/utils.py
+++ b/src/fake_useragent/utils.py
@@ -45,8 +45,7 @@ def load() -> list[BrowserUserAgentData]:
     """
     path = Path(__file__, "../data/browsers.jsonl").resolve()
     try:
-        with path.open() as f:
-            return list(map(json.loads, f))
+        return json.loads(f"[{path.read_text().rstrip().replace('\n', ',')}]")
     except Exception as exc:
         if not path.is_file():
             logger.warning(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -21,13 +21,7 @@ class TestUtils(unittest.TestCase):
 
         self.assertGreater(len(data), 1000)
 
-        if sys.version_info >= (3, 12):
-            # pydantic only supports `typing_extensions.TypedDict` instead of `typing.TypedDict` on Python < 3.12.
-
-            from pydantic import TypeAdapter
-
-            validator = TypeAdapter(List[utils.BrowserUserAgentData])
-            validator.validate_python(data, strict=True)
+        validate_types(data)
 
     def test_utils_load_from_zipimport(self):
         with make_temporary_directory() as temp_dir:
@@ -50,6 +44,7 @@ class TestUtils(unittest.TestCase):
             data = utils.load()
 
         self.assertGreater(len(data), 1000)
+        validate_types(data)
 
         # cleanup
         unload_module("fake_useragent")
@@ -83,3 +78,12 @@ def make_temporary_directory():
                 importlib.invalidate_caches()
                 gc.collect()
                 d.cleanup()
+
+
+def validate_types(data: List[utils.BrowserUserAgentData]):
+    if sys.version_info < (3, 12):
+        return  # pydantic only supports `typing_extensions.TypedDict` instead of `typing.TypedDict` on Python < 3.12.
+
+    from pydantic import TypeAdapter
+
+    TypeAdapter(List[utils.BrowserUserAgentData]).validate_python(data, strict=True)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,10 @@
+import sys
 import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import TYPE_CHECKING
+from zipfile import ZipFile
+from zipimport import zipimporter
 
 from fake_useragent import utils
 
@@ -25,3 +31,43 @@ class TestUtils(unittest.TestCase):
         self.assertIsInstance(data[0]["os"], str)
         self.assertIsInstance(data[0]["os_version"], str)
         self.assertIsInstance(data[0]["platform"], str)
+
+    def test_utils_load_from_zipimport(self):
+        with TemporaryDirectory() as d:
+            filename = Path(d, "module.zip")
+            with ZipFile(filename, "w") as z:
+                for file in Path("src").rglob("*"):
+                    z.write(file, file.relative_to("src"))
+
+            unload_module("fake_useragent")  # cleanup previous imports
+
+            importer = zipimporter(str(filename))
+            spec = importer.find_spec("fake_useragent")
+            self.assertIsNotNone(spec)
+            loader = spec.loader
+            self.assertIsNotNone(loader)
+            if not TYPE_CHECKING:
+                utils = loader.load_module("fake_useragent").utils
+
+            data = utils.load()
+
+        self.assertIsInstance(data, list)
+        self.assertGreater(len(data), 1000)
+        self.assertIsInstance(data[0], object)
+        self.assertIsInstance(data[0]["percent"], float)
+        self.assertIsInstance(data[0]["type"], str)
+        self.assertIsInstance(data[0]["device_brand"], str)
+        self.assertIsInstance(data[0]["browser"], str)
+        self.assertIsInstance(data[0]["browser_version"], str)
+        self.assertIsInstance(data[0]["browser_version_major_minor"], float)
+        self.assertIsInstance(data[0]["os"], str)
+        self.assertIsInstance(data[0]["os_version"], str)
+        self.assertIsInstance(data[0]["platform"], str)
+
+        unload_module("fake_useragent")  # cleanup
+
+
+def unload_module(name: str):
+    for module in tuple(sys.modules):
+        if name in module:
+            del sys.modules[module]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,6 +6,7 @@ from importlib import invalidate_caches
 from pathlib import Path
 from shutil import make_archive
 from tempfile import TemporaryDirectory
+from typing import List
 
 from fake_useragent import utils
 
@@ -20,18 +21,18 @@ class TestUtils(unittest.TestCase):
     def test_utils_load(self):
         data = utils.load()
 
-        self.assertIsInstance(data, list)
         self.assertGreater(len(data), 1000)
-        self.assertIsInstance(data[0], object)
-        self.assertIsInstance(data[0]["percent"], float)
-        self.assertIsInstance(data[0]["type"], str)
-        self.assertIsInstance(data[0]["device_brand"], str)
-        self.assertIsInstance(data[0]["browser"], str)
-        self.assertIsInstance(data[0]["browser_version"], str)
-        self.assertIsInstance(data[0]["browser_version_major_minor"], float)
-        self.assertIsInstance(data[0]["os"], str)
-        self.assertIsInstance(data[0]["os_version"], str)
-        self.assertIsInstance(data[0]["platform"], str)
+
+        if sys.version_info < (3, 12):
+            from pytest import skip
+
+            skip(
+                "pydantic only supports `typing_extensions.TypedDict` instead of `typing.TypedDict` on Python < 3.12."
+            )
+
+        from pydantic import TypeAdapter
+
+        TypeAdapter(List[utils.BrowserUserAgentData]).validate_python(data, strict=True)
 
     def test_utils_load_from_zipimport(self):
         with make_temporary_directory() as temp_dir:
@@ -53,18 +54,7 @@ class TestUtils(unittest.TestCase):
 
             data = utils.load()
 
-        self.assertIsInstance(data, list)
         self.assertGreater(len(data), 1000)
-        self.assertIsInstance(data[0], object)
-        self.assertIsInstance(data[0]["percent"], float)
-        self.assertIsInstance(data[0]["type"], str)
-        self.assertIsInstance(data[0]["device_brand"], str)
-        self.assertIsInstance(data[0]["browser"], str)
-        self.assertIsInstance(data[0]["browser_version"], str)
-        self.assertIsInstance(data[0]["browser_version_major_minor"], float)
-        self.assertIsInstance(data[0]["os"], str)
-        self.assertIsInstance(data[0]["os_version"], str)
-        self.assertIsInstance(data[0]["platform"], str)
 
         # cleanup
         unload_module("fake_useragent")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,7 +3,6 @@ import sys
 import unittest
 from importlib import invalidate_caches
 from pathlib import Path
-from shutil import rmtree
 from tempfile import TemporaryDirectory
 from zipfile import ZipFile
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,8 +3,8 @@ import sys
 import unittest
 from importlib import invalidate_caches
 from pathlib import Path
+from shutil import make_archive
 from tempfile import TemporaryDirectory
-from zipfile import ZipFile
 
 from fake_useragent import utils
 
@@ -36,7 +36,7 @@ class TestUtils(unittest.TestCase):
         d = TemporaryDirectory()
         zip_filename = str(Path(d.name, "module.zip"))
 
-        make_zip("src", zip_filename)
+        make_archive(zip_filename.removesuffix(".zip"), "zip", "src")
 
         unload_module("fake_useragent")  # cleanup previous imports
 
@@ -76,12 +76,6 @@ class TestUtils(unittest.TestCase):
             # because the module is still in use
             invalidate_caches()
             atexit.register(d.cleanup)
-
-
-def make_zip(source_dir: str, output_file: str):
-    with ZipFile(output_file, "w") as z:
-        for file in Path(source_dir).rglob("*"):
-            z.write(file, file.relative_to(source_dir))
 
 
 def unload_module(name: str):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -34,14 +34,13 @@ class TestUtils(unittest.TestCase):
 
     def test_utils_load_from_zipimport(self):
         d = TemporaryDirectory()
-        filename = Path(d.name, "module.zip")
-        with ZipFile(filename, "w") as z:
-            for file in Path("src").rglob("*"):
-                z.write(file, file.relative_to("src"))
+        zip_filename = str(Path(d.name, "module.zip"))
+
+        make_zip("src", zip_filename)
 
         unload_module("fake_useragent")  # cleanup previous imports
 
-        sys.path.insert(0, str(filename))
+        sys.path.insert(0, zip_filename)
 
         from fake_useragent import utils
 
@@ -68,7 +67,7 @@ class TestUtils(unittest.TestCase):
 
         # cleanup
         unload_module("fake_useragent")
-        sys.path.remove(str(filename))
+        sys.path.remove(zip_filename)
 
         try:
             d.cleanup()
@@ -77,6 +76,12 @@ class TestUtils(unittest.TestCase):
             # because the module is still in use
             invalidate_caches()
             atexit.register(d.cleanup)
+
+
+def make_zip(source_dir: str, output_file: str):
+    with ZipFile(output_file, "w") as z:
+        for file in Path(source_dir).rglob("*"):
+            z.write(file, file.relative_to(source_dir))
 
 
 def unload_module(name: str):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -82,9 +82,11 @@ def make_temporary_directory():
     d = TemporaryDirectory()
     try:
         yield d.name
-        d.cleanup()
-    except PermissionError:
-        # Windows users will fail to remove the temporary directory
-        # because the module is still in use
-        invalidate_caches()
-        atexit.register(d.cleanup)
+    finally:
+        try:
+            d.cleanup()
+        except PermissionError:
+            # Windows users will fail to remove the temporary directory
+            # because the module is still in use
+            invalidate_caches()
+            atexit.register(d.cleanup)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,12 +1,4 @@
-import sys
-
-if sys.version_info >= (3, 10):
-    import importlib.resources as ilr
-else:
-    import importlib_resources as ilr
-
 import unittest
-from unittest.mock import patch
 
 from fake_useragent import utils
 
@@ -20,31 +12,6 @@ class TestUtils(unittest.TestCase):
 
     def test_utils_load(self):
         data = utils.load()
-
-        self.assertIsInstance(data, list)
-        self.assertGreater(len(data), 1000)
-        self.assertIsInstance(data[0], object)
-        self.assertIsInstance(data[0]["percent"], float)
-        self.assertIsInstance(data[0]["type"], str)
-        self.assertIsInstance(data[0]["device_brand"], str)
-        self.assertIsInstance(data[0]["browser"], str)
-        self.assertIsInstance(data[0]["browser_version"], str)
-        self.assertIsInstance(data[0]["browser_version_major_minor"], float)
-        self.assertIsInstance(data[0]["os"], str)
-        self.assertIsInstance(data[0]["os_version"], str)
-        self.assertIsInstance(data[0]["platform"], str)
-
-    # https://github.com/python/cpython/issues/95299
-    @unittest.skipIf(
-        sys.version_info >= (3, 12), "not compatible with Python 3.12 (or higher)"
-    )
-    def test_utils_load_pkg_resource_fallback(self):
-        # By default use_local_file is also True during production
-        # We will not allow the default importlib resources to be used, by triggering an Exception
-        with patch.object(ilr, "files") as mocked_importlib_resources_files:
-            # This exception should trigger the alternative path, trying to use pkg_resource as fallback
-            mocked_importlib_resources_files.side_effect = Exception("Error")
-            data = utils.load()
 
         self.assertIsInstance(data, list)
         self.assertGreater(len(data), 1000)

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ skip_missing_interpreters = True
 [testenv]
 deps =
     black
+    pydantic
     pytest
     pytest-cov
     validate-pyproject


### PR DESCRIPTION
This PR improves data loading in two ways:

1. Resolving the `browsers.jsonl` file using `pkgutil` instead `importlib.resources` or `pkg_resources`, which makes `importlib-resources` no longer required in python<3.10
2. Use a hacky way to parse the jsonl data to speed up `load()` 2.2x

BTW, a new testcase is added [to ensure that this package is zipimport-compatible](#issuecomment-2532740132).

<details><summary>Details</summary>
<p>

This pull request includes several changes to the `fake_useragent` package to simplify the codebase and improve compatibility. The most important changes involve removing the dependency on `importlib-resources`, updating the `load` function to use `pkgutil`, and enhancing the test suite.

Codebase simplification:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L13-R13): Removed the dependency on `importlib-resources` for Python versions below 3.10.
* [`src/fake_useragent/utils.py`](diffhunk://#diff-eaceb65d44c0eb2ed1b5108e3e0863edd4c31e7d16d3f7ac5e041ae70b87ce8bL4-R5): Simplified imports by removing the conditional import of `importlib-resources` and using `pkgutil` instead.
* [`src/fake_useragent/utils.py`](diffhunk://#diff-eaceb65d44c0eb2ed1b5108e3e0863edd4c31e7d16d3f7ac5e041ae70b87ce8bL52-R52): Updated the `load` function to use `pkgutil.get_data` for reading the `browsers.jsonl` file, removing the fallback logic for `importlib-resources` and `pkg_resources`.

Test suite enhancements:

* [`tests/test_utils.py`](diffhunk://#diff-33c13e0b177bacd2f02e29bcb8aea5b49e7ce34901fd8f41fefb65defba1bd33L2-R5): Removed the conditional import of `importlib-resources` and added new tests to verify loading from a zip file. [[1]](diffhunk://#diff-33c13e0b177bacd2f02e29bcb8aea5b49e7ce34901fd8f41fefb65defba1bd33L2-R5) [[2]](diffhunk://#diff-33c13e0b177bacd2f02e29bcb8aea5b49e7ce34901fd8f41fefb65defba1bd33L37-R51)
* [`tests/test_utils.py`](diffhunk://#diff-33c13e0b177bacd2f02e29bcb8aea5b49e7ce34901fd8f41fefb65defba1bd33R66-R74): Added a utility function `unload_module` to clean up modules after tests.

</p>
</details>