### PR TITLE
Trigger only once per month

### DIFF
--- a/.github/workflows/update_bundled_useragents.yml
+++ b/.github/workflows/update_bundled_useragents.yml
@@ -2,7 +2,7 @@ name: Update Bundled User Agents
 
 on:
   schedule:
-    - cron: '0 0 * * 0'  # Run weekly on Sunday at midnight
+    - cron: '2 4 2 * 0'  # Run monthly (2nd day of the month) on Sunday at 4:02 at night
   workflow_dispatch:  # Allow manual trigger
 
 permissions:


### PR DESCRIPTION
As discussed, only trigger the update job once per month.

Also avoid specific busy / rounded trigger times like 00:00. Or 1:00. So I went with 4:02 am. Each second day of the month.