### PR TITLE
Check for dunder attributes in FakeUserAgent.__getattr__() and make safe_attrs = ['shape'] by default

### DIFF
--- a/src/fake_useragent/fake.py
+++ b/src/fake_useragent/fake.py
@@ -108,7 +108,7 @@ class FakeUserAgent:
         safe_attrs (Optional[Iterable[str]], optional): `FakeUserAgent` uses a custom `__getattr__`
             to facilitate retrieval of user agents by browser. If you need to prevent some
             attributes from being treated as browsers, pass them here. If None, all attributes will
-            be treated as browsers. Defaults to None.
+            be treated as browsers. Defaults to ["shape"] to prevent unintended calls in IDEs like PyCharm.
 
     Raises:
         TypeError: If `fallback` isn't a `str` or `safe_attrs` contains non-`str` values.
@@ -181,6 +181,8 @@ class FakeUserAgent:
             raise TypeError(msg)
         self.fallback = fallback
 
+        if safe_attrs is None:
+            safe_attrs = ["shape"]
         safe_attrs = _ensure_iterable(safe_attrs=safe_attrs, default=set())
         str_safe_attrs = [isinstance(attr, str) for attr in safe_attrs]
         if not all(str_safe_attrs):

--- a/src/fake_useragent/fake.py
+++ b/src/fake_useragent/fake.py
@@ -65,6 +65,24 @@ def _ensure_float(value: Any) -> float:
         raise ValueError(msg) from ve
 
 
+def _is_magic_name(attribute_name: str) -> bool:
+    """Judge whether the given attribute name is the name of a magic method(e.g. __iter__).
+
+    Args:
+        attribute_name (str): The attribute name to check.
+
+    Returns:
+        bool: Whether the given attribute name is magic.
+    """
+    magic_min_length = 2 * len("__") + 1
+    return (
+        len(attribute_name) >= magic_min_length
+        and attribute_name.isascii()
+        and attribute_name.startswith("__")
+        and attribute_name.endswith("__")
+    )
+
+
 class FakeUserAgent:
     """Fake User Agent retriever.
 
@@ -288,7 +306,7 @@ class FakeUserAgent:
                 attribute value.
         """
         if isinstance(attr, str):
-            if attr in self.safe_attrs:
+            if _is_magic_name(attr) or attr in self.safe_attrs:
                 return super(UserAgent, self).__getattribute__(attr)
         elif isinstance(attr, list):
             for a in attr:


### PR DESCRIPTION
As mentioned in https://github.com/fake-useragent/fake-useragent/issues/446#issuecomment-2709356368 , the FakeUserAgent overrides `__getattr__` to respond to wildcard attribute accesses, but this may lead to unintended calls to `getBrowser` when it comes to dunder attributes. For example, one may see a confusing warning `fake: Error occurred during getting browser(s): __iter__, but was suppressed with fallback.` when they mistakenly call `for item in ua:` . 

Additionally, PyCharm automatically checks `variable.shape` and `variable.__len__()` in interactive shell and debug view, [which may also lead to some confusing warnings](https://github.com/fake-useragent/fake-useragent/issues/446#issue-2825540229) like `Error occurred during getting browser(s): shape, but was suppressed with fallback.` . 

Therefore, I updated fake.py to add a check for dunder attributes and change the default value of `safe_attrs` to `['shape']`. I think that the new default value is safe as no browser or platform is named 'shape', but if you really think this is unacceptable, you may also accept only the first commit that implements the check for dunders.