### PR TITLE
Fix Python version requirement for 2.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,12 +4,13 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fake-useragent"
-version = "2.0.0"
+version = "2.0.0.post1"
 authors = [
     { name = "Melroy van den Berg", email = "melroy@melroy.org" },
     { name = "Victor Kovtun", email = "hellysmile@gmail.com" },
 ]
-dependencies = ["importlib-resources >= 5.0; python_version < '3.10'"]
+requires-python = ">=3.9"
+dependencies = ["importlib-resources >= 5.0; python_version<'3.10'"]
 description = "Up-to-date simple useragent faker with real world database"
 keywords = [
     "user",


### PR DESCRIPTION
This PR is intended to be merged to the "2.0.0" tag (or rather, into a new branch spawned off that tag).

When I run `pip install fake_useragent` in Python 3.8, it installs 2.0.0 which uses 3.9 syntax:

<details>

```
In [15]: import requests_html                                                    
---------------------------------------------------------------------------      
<...>                                                                                 
File ~\AppData\Roaming\Python\Python38\site-packages\fake_useragent\utils.py:42  
     38     platform: str                                                        
     39     """Platform for the user agent (eg. Linux armv81)."""                
---> 42 def load() -> list[BrowserUserAgentData]:                                
     43     """Load the included `browsers.jsonl` file into memory..             
     44                                                                          
     45     Raises:                                                              
   (...)                                                                         
     50             `BrowserUserAgentData` schema.                               
     51     """                                                                  
     52     data = []                                                            
                                                                                 
TypeError: 'type' object is not subscriptable                                    
```

</details>

To fix this, as per https://snarky.ca/what-to-do-when-you-botch-a-release-on-pypi/ , one needs to make another release and yank the faulty release.