### PR TITLE
Normalize float validation errors for non-convertible inputs

### DIFF
--- a/src/fake_useragent/fake.py
+++ b/src/fake_useragent/fake.py
@@ -60,9 +60,9 @@ def _ensure_float(value: Any) -> float:
     """
     try:
         return float(value)
-    except ValueError as ve:
-        msg = f"Value must be convertible to float but got {value}."
-        raise ValueError(msg) from ve
+    except (ValueError, TypeError) as exc:
+        msg = f"Value must be convertible to float but got {value!r}."
+        raise ValueError(msg) from exc
 
 
 def _is_magic_name(attribute_name: str) -> bool:

--- a/tests/test_fake.py
+++ b/tests/test_fake.py
@@ -110,9 +110,15 @@ class TestFake(unittest.TestCase):
         with pytest.raises(ValueError):
             UserAgent(min_percentage="")
 
+        with pytest.raises(ValueError):
+            UserAgent(min_percentage=None)
+
     def test_fake_min_version_float_types(self):
         with pytest.raises(ValueError):
             UserAgent(min_version="")
+
+        with pytest.raises(ValueError):
+            UserAgent(min_version=None)
 
     def test_fake_safe_attrs_iterable_str_types(self):
         with pytest.raises(TypeError):


### PR DESCRIPTION
## What changed
- Normalized float validation in `FakeUserAgent` by handling both `ValueError` and `TypeError` in `_ensure_float()` and re-raising as a consistent `ValueError`.
- Improved the validation message to include `repr(value)` so inputs like `None` are unambiguous in error output.
- Added tests to cover non-string invalid inputs:
  - `UserAgent(min_version=None)`
  - `UserAgent(min_percentage=None)`

## Insight / Why this matters
`_ensure_float()` previously only converted `ValueError` to a user-facing validation error. However, `float(None)` raises `TypeError`, so callers would see an inconsistent low-level exception path depending on the invalid input type.

This is easy to miss because existing tests already covered invalid strings (`""`), which do raise `ValueError`, so the alternate `TypeError` path stayed hidden.

Practical impact:
- More predictable API behavior for callers and wrappers.
- Better reliability in config/CLI flows where values may be absent (`None`).
- Reduced debugging time via consistent exception type and clearer message.

Tradeoff/risk:
- Very low-risk and rollback-safe; only error normalization behavior changed for invalid inputs.
- No behavior change for valid inputs.

## Why
The library already documents/uses `ValueError` semantics for invalid numeric config values. This change makes that contract consistent across common invalid input classes.

## Testing
- ✅ Reproduced and validated behavior for `None` inputs:
  - `python - <<'PY' ... UserAgent(min_version=None) ... UserAgent(min_percentage=None) ... PY`
  - Observed both now raise `ValueError` with clear messages.
- ✅ Targeted tests:
  - `pytest -q tests/test_fake.py::TestFake::test_fake_percentage_float_types tests/test_fake.py::TestFake::test_fake_min_version_float_types`
- ✅ Full suite:
  - `pytest -q`
