### PR TITLE
feat: add randomizer param to FakeUserAgent for deterministic output

### DIFF
--- a/src/fake_useragent/fake.py
+++ b/src/fake_useragent/fake.py
@@ -109,6 +109,10 @@ class FakeUserAgent:
             to facilitate retrieval of user agents by browser. If you need to prevent some
             attributes from being treated as browsers, pass them here. If None, all attributes will
             be treated as browsers. Defaults to ["shape"] to prevent unintended calls in IDEs like PyCharm.
+        randomizer (Optional[random.Random], optional): Custom ``random.Random`` instance used
+            when picking user agents. Pass ``random.Random(seed)`` for deterministic results
+            (useful in tests or reproducible pipelines). Defaults to None, which uses the
+            module-level ``random``.
 
     Raises:
         TypeError: If `fallback` isn't a `str` or `safe_attrs` contains non-`str` values.
@@ -127,6 +131,7 @@ class FakeUserAgent:
             "Chrome/122.0.0.0 Safari/537.36 Edg/122.0.0.0"
         ),
         safe_attrs: Optional[Iterable[str]] = None,
+        randomizer: Optional[random.Random] = None,
     ):
         self.browsers = _ensure_iterable(
             browsers=browsers,
@@ -193,6 +198,8 @@ class FakeUserAgent:
             raise TypeError(msg)
         self.safe_attrs = set(safe_attrs)
 
+        self._rng = randomizer if randomizer is not None else random
+
         # Next, load our local data file into memory (browsers.jsonl)
         self.data_browsers = load()
 
@@ -221,7 +228,7 @@ class FakeUserAgent:
 
             # Pick a random browser user-agent from the filtered browsers
             # And return the full dict
-            return random.choice(filtered_browsers)  # noqa: S311
+            return self._rng.choice(filtered_browsers)  # noqa: S311
         except (KeyError, IndexError):
             logger.warning(
                 f"Error occurred during getting browser(s): {browsers}, "


### PR DESCRIPTION
Closes #432

There's currently no way to make `FakeUserAgent` output deterministic, which makes testing and reproducible scraping pipelines harder than it needs to be.

This adds an optional `randomizer` parameter to `__init__`:

```python
import random
ua = FakeUserAgent(randomizer=random.Random(42))
# same seed = same sequence every time
print(ua.random)  # reproducible
```

If `randomizer` is not passed, the behavior is exactly the same as before (falls back to module-level `random`). No breaking changes.

Internally, `getBrowser` now uses `self._rng.choice(...)` instead of `random.choice(...)`.